### PR TITLE
Fix service configuration

### DIFF
--- a/src/BroadcasttServiceProvider.php
+++ b/src/BroadcasttServiceProvider.php
@@ -35,6 +35,7 @@ class BroadcasttServiceProvider extends ServiceProvider
     {
         $source = realpath(__DIR__.'/../config/broadcastt.php');
         $this->publishes([$source => config_path('broadcastt.php')]);
+        $this->mergeConfigFrom($source, 'broadcastt');
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,15 +19,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             'secret' => env('BROADCASTER_APP_SECRET'),
             'cluster' => env('BROADCASTER_APP_CLUSTER'),
         ]);
-
-        $config->set('broadcastt.default', 'main');
-
-        $config->set('broadcastt.connections.main', [
-            'id' => env('BROADCASTER_APP_ID'),
-            'key' => env('BROADCASTER_APP_KEY'),
-            'secret' => env('BROADCASTER_APP_SECRET'),
-            'cluster' => env('BROADCASTER_APP_CLUSTER'),
-        ]);
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
This PR adds a call to `mergeConfigFrom` to add default configuration to Laravel's configuration repository.